### PR TITLE
Fixes to Controller & Composer Version Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "5.5.*",
-        "encore/laravel-admin": "1.5.*"
+        "laravel/framework": "~5.5",
+        "encore/laravel-admin": "~1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/src/BootExtension.php
+++ b/src/BootExtension.php
@@ -36,7 +36,7 @@ trait BootExtension
      */
     public static function import()
     {
-        parent::createMenu('Log viwer', 'logs', 'fa-database');
+        parent::createMenu('Log Viewer', 'logs', 'fa-database');
 
         parent::createPermission('Logs', 'ext.log-viewer', 'logs*');
     }

--- a/src/LogController.php
+++ b/src/LogController.php
@@ -9,8 +9,12 @@ use Illuminate\Routing\Controller;
 
 class LogController extends Controller
 {
-    public function index($file, Request $request)
+    public function index($file = null, Request $request)
     {
+        if($file === null) {
+            $file = (new LogViewer())->getLastModifiedLog();
+        }
+
         return Admin::content(function (Content $content) use ($file, $request) {
             $offset = $request->get('offset');
 

--- a/src/LogController.php
+++ b/src/LogController.php
@@ -11,7 +11,7 @@ class LogController extends Controller
 {
     public function index($file = null, Request $request)
     {
-        if($file === null) {
+        if ($file === null) {
             $file = (new LogViewer())->getLastModifiedLog();
         }
 


### PR DESCRIPTION
Loosened the Laravel version dependency to allow installation on Laravel 5.6 and later, also changed the controller to make the index view automatically resolve to the latest log file rather than failing with an exception as was the case.