### PR TITLE
Remove .log file extension from URL

### DIFF
--- a/src/LogController.php
+++ b/src/LogController.php
@@ -40,7 +40,7 @@ class LogController extends Controller
     {
         $offset = $request->get('offset');
 
-        $viewer = new LogViewer($file);
+        $viewer = new LogViewer($file.".log");
 
         list($pos, $logs) = $viewer->tail($offset);
 

--- a/src/LogViewer.php
+++ b/src/LogViewer.php
@@ -72,7 +72,7 @@ class LogViewer extends Extension
     public function getFilePath()
     {
         if (!$this->filePath) {
-            $path = sprintf(storage_path('logs/%s'), $this->file);
+            $path = sprintf(storage_path('logs/%s').".log", $this->file);
 
             if (!file_exists($path)) {
                 throw new \Exception('log not exists!');
@@ -103,11 +103,12 @@ class LogViewer extends Extension
      */
     public function getLogFiles($count = 20)
     {
-        $files = glob(storage_path('logs/*'));
+        $files = glob(storage_path('logs/*.log'));
         $files = array_combine($files, array_map('filemtime', $files));
         arsort($files);
 
         $files = array_map('basename', array_keys($files));
+        $files = array_map(function($x){ return str_replace(".log", "", $x);}, $files);
 
         return array_slice($files, 0, $count);
     }


### PR DESCRIPTION
If URL endwith .log, many servers don't allow this request for security.

Example: Not working with IIS 7.5 server