### PR TITLE
Update composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "encore/laravel-admin": "~1.6"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "~6.0"
+        "encore/laravel-admin": "^1.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Require laravel-admin 1.6 version and above
Remove phpunit/phpunit requirement because it not used by repository